### PR TITLE
Updated the README to reflect changes in Xcode 7.0 - 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 
 **Xcode >= 7.0**
 
-1.  Change the theme file's extension to ``.xccolortheme``
-2.	Copy the theme file to the Xcode's ``FontAndColorThemes`` folder ``(/Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/FontAndColorThemes/)``.
-3.  Restart Xcode.
-4.	Apply theme.
+1. Change the theme file's extension to ``.xccolortheme``
+2. Copy the theme file to the Xcode's ``FontAndColorThemes`` folder ``(/Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/FontAndColorThemes/)``.
+3. Restart Xcode.
+4. Apply theme.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Monokai Revisited Xcode Theme
 =======================
 
 Another take on the Monokai theme for Xcode, with a couple of subtle changes like string, project function names and selection coloring.
-Preview screenshots include the beautiful [Input] (http://input.fontbureau.com/) font by Font Bureau. 
+Preview screenshots include the beautiful [Input](http://input.fontbureau.com/) font by Font Bureau. 
 
 ![Monokai Xcode Theme](http://f.cl.ly/items/2r122h2U0A3Q3L0a1a2l/monokai_revisited_preview.png)
 
@@ -13,6 +13,15 @@ Differences
 Installation
 =======================
 
+**Xcode < 7.0**
+
 1. Copy the theme file to the Xcode's ``FontAndColorThemes`` folder ``(~/Library/Developer/Xcode/UserData/FontAndColorThemes/)``.
 2. Restart Xcode.
 3. Apply theme.
+
+**Xcode >= 7.0**
+
+1.  Change the theme file's extension to ``.xccolortheme``
+2.	Copy the theme file to the Xcode's ``FontAndColorThemes`` folder ``(/Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/FontAndColorThemes/)``.
+3.  Restart Xcode.
+4.	Apply theme.


### PR DESCRIPTION
Updated the 'Installation' section of the README to clarify for users using Xcode 7.0 >=

Changes 
=======================
- Theme file extension is now ``.xccolortheme``
- ``FontAndColorThemes`` folder is now located at ``/Applications/Xcode.app/Contents/SharedFrameworks/DVTKit.framework/Versions/A/Resources/FontAndColorThemes/``.